### PR TITLE
Improve results page layout and styling

### DIFF
--- a/client/components/results/ResultsList.tsx
+++ b/client/components/results/ResultsList.tsx
@@ -129,14 +129,11 @@ function FieldList({ fields }: { fields: ResultField[] }) {
       {fields.map((field) => {
         const label = field.label?.trim() || formatLabel(field.key);
         return (
-          <div
-            key={field.key}
-            className="grid gap-y-2 gap-x-6 px-5 py-4 sm:grid-cols-[minmax(160px,0.35fr)_1fr]"
-          >
-            <dt className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+          <div key={field.key} className="px-5 py-4 space-y-1">
+            <dt className="text-sm md:text-base font-bold text-foreground">
               {label}
             </dt>
-            <dd className="min-w-0 text-sm font-medium leading-6 text-foreground break-words md:text-base">
+            <dd className="min-w-0 text-sm md:text-base font-medium leading-6 text-foreground break-words">
               <ValueRenderer value={field.value} />
             </dd>
           </div>
@@ -230,14 +227,11 @@ function ObjectRenderer({ obj }: { obj: Record<string, ResultValue> }) {
   return (
     <dl className="space-y-3">
       {entries.map(([key, val]) => (
-        <div
-          key={key}
-          className="grid gap-y-1 gap-x-4 rounded-xl bg-background px-3 py-2 sm:grid-cols-[minmax(140px,0.35fr)_1fr]"
-        >
-          <dt className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+        <div key={key} className="rounded-xl bg-background px-3 py-2 space-y-1">
+          <dt className="text-sm md:text-base font-bold text-foreground">
             {formatLabel(key)}
           </dt>
-          <dd className="text-sm font-medium text-foreground/80">
+          <dd className="text-sm md:text-base font-medium text-foreground/90">
             <ValueRenderer value={val} />
           </dd>
         </div>

--- a/client/pages/SearchResults.tsx
+++ b/client/pages/SearchResults.tsx
@@ -304,7 +304,7 @@ function SummarySources({ sources }: { sources: string[] }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="inline-flex items-center rounded-full border border-brand-600/40 bg-brand-500/15 px-2.5 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-foreground">
-        Osint Info
+        Osint Info DBs
       </span>
       {display.map((source) => (
         <span

--- a/client/pages/SearchResults.tsx
+++ b/client/pages/SearchResults.tsx
@@ -234,7 +234,7 @@ export default function SearchResults() {
               </aside>
             </div>
 
-            <section className="mx-auto max-w-3xl rounded-[2rem] border border-border/70 bg-background p-6 shadow-lg overflow-hidden">
+            <section className="rounded-[2rem] border border-border/70 bg-background p-6 shadow-lg overflow-hidden lg:mx-0 lg:max-w-none">
               <header className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h2 className="text-lg font-semibold text-foreground md:text-xl">


### PR DESCRIPTION
## Purpose
The user requested improvements to the results page layout and design to enhance readability and organization. They wanted results displayed on the left side with better positioning, field labels to be bold and prominent, sources information positioned above results rather than beside them, and the data sources section to be labeled as "Osint Info DBs".

## Code changes
- **Layout restructuring**: Removed grid-based layout in favor of vertical stacking with `space-y-1` for better left-aligned positioning
- **Typography improvements**: Changed field labels from small uppercase text to bold, larger font sizes (`text-sm md:text-base font-bold`)
- **Results container**: Removed max-width constraints and centering (`lg:mx-0 lg:max-w-none`) to allow full-width display
- **Data sources label**: Updated from "Osint Info" to "Osint Info DBs" as requested
- **Visual hierarchy**: Enhanced contrast and readability by adjusting text colors and removing excessive spacing

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a00e2e0d36ed4139a6ff9da4ebf425be/pulse-field)

👀 [Preview Link](https://a00e2e0d36ed4139a6ff9da4ebf425be-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a00e2e0d36ed4139a6ff9da4ebf425be</projectId>-->
<!--<branchName>pulse-field</branchName>-->